### PR TITLE
Removing custom hash implementation

### DIFF
--- a/AOC/Library/Position.swift
+++ b/AOC/Library/Position.swift
@@ -51,7 +51,7 @@ public enum Heading: CaseIterable {
 
 public struct Position: Hashable {
     public static func ==(lhs: Position, rhs: Position) -> Bool { return lhs.x == rhs.x && lhs.y == rhs.y }
-    public var hashValue: Int { return x * 1000 + y}
+
     public let x: Int
     public let y: Int
     


### PR DESCRIPTION
Removing custom hash implementation because this is a struct which ge… its own hash.  Alternatively,

```
public func hash(into hasher: inout Hasher) {
        hasher.combine(x)
        hasher.combine(y)
    }
```

could be used.